### PR TITLE
spencer/0.17 updates

### DIFF
--- a/charts/vector-agent/CHANGELOG.md
+++ b/charts/vector-agent/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Vector Agent Changelog
+
+## 0.17.0
+
+* Port `args`, `livenessProbe`, `readinessProbe`, `dnsPolicy`, `dnsConfig`, and `secrets` from original charts
+* Add `service.annotations` support

--- a/charts/vector-agent/Chart.yaml
+++ b/charts/vector-agent/Chart.yaml
@@ -3,7 +3,7 @@ name: vector-agent
 type: application
 icon: https://vector.dev/press/vector-icon.svg
 description: A Helm chart to collect Kubernetes logs with Vector
-version: "0.16.1"
+version: "0.17.0"
 appVersion: "0.16.1"
 home: https://vector.dev/
 sources:

--- a/charts/vector-agent/templates/daemonset.yaml
+++ b/charts/vector-agent/templates/daemonset.yaml
@@ -48,6 +48,9 @@ spec:
           args:
             - --config-dir
             - /etc/vector/
+            {{- with .Values.args }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
             - name: VECTOR_SELF_NODE_NAME
               valueFrom:
@@ -74,6 +77,14 @@ spec:
             {{- with .Values.extraContainersPorts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | trim | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | trim | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.lifecycle }}
@@ -112,6 +123,13 @@ spec:
             # Extra volumes.
             {{- toYaml . | nindent 12 }}
             {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml .Values.dnsConfig | trim | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 60
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/vector-agent/templates/secret.yaml
+++ b/charts/vector-agent/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- with .Values.secrets.generic }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "libvector.fullname" $ }}
+  labels:
+    {{- include "libvector.labels" $ | nindent 4 }}
+type: Opaque
+data:
+{{- range $key, $value := $.Values.secrets.generic }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}

--- a/charts/vector-agent/templates/service.yaml
+++ b/charts/vector-agent/templates/service.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ include "libvector.fullname" . }}
   labels:
     {{- include "libvector.labels" . | nindent 4 }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- with .Values.service.ports }}

--- a/charts/vector-agent/values.yaml
+++ b/charts/vector-agent/values.yaml
@@ -73,6 +73,7 @@ dnsConfig: {}
 service:
   # Whether to create service resource or not.
   enabled: false
+  annotations: {}
   type: ClusterIP
   topologyKeys: {}
   # List of valid topologyKeys values.

--- a/charts/vector-aggregator/CHANGELOG.md
+++ b/charts/vector-aggregator/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Vector Aggregator Changelog
+
+## 0.17.0
+
+* Port `args`, `livenessProbe`, `readinessProbe`, `dnsPolicy`, `dnsConfig`, and `secrets` from original charts
+* Add `service.annotations` support (non-headless service)
+* Remove default tolerations allowing pods to be scheduled on `node-role.kubernetes.io/master` nodes

--- a/charts/vector-aggregator/Chart.yaml
+++ b/charts/vector-aggregator/Chart.yaml
@@ -3,7 +3,7 @@ name: vector-aggregator
 type: application
 icon: https://vector.dev/press/vector-icon.svg
 description: A Helm chart to aggregate data with Vector
-version: "0.16.1"
+version: "0.17.0"
 appVersion: "0.16.1"
 home: https://vector.dev/
 sources:

--- a/charts/vector-aggregator/templates/secret.yaml
+++ b/charts/vector-aggregator/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- with .Values.secrets.generic }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "libvector.fullname" $ }}
+  labels:
+    {{- include "libvector.labels" $ | nindent 4 }}
+type: Opaque
+data:
+{{- range $key, $value := $.Values.secrets.generic }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}

--- a/charts/vector-aggregator/templates/service.yaml
+++ b/charts/vector-aggregator/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "libvector.fullname" . }}
   labels:
     {{- include "libvector.labels" . | nindent 4 }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/vector-aggregator/templates/statefulset.yaml
+++ b/charts/vector-aggregator/templates/statefulset.yaml
@@ -44,6 +44,9 @@ spec:
           args:
             - --config-dir
             - /etc/vector/
+            {{- with .Values.args }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
             {{- include "libvector.globalEnv" . | nindent 12 }}
             {{- with .Values.env }}
@@ -54,6 +57,14 @@ spec:
             {{- with .Values.extraContainersPorts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | trim | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | trim | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
@@ -72,6 +83,13 @@ spec:
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml .Values.dnsConfig | trim | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 60
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/vector-aggregator/values.yaml
+++ b/charts/vector-aggregator/values.yaml
@@ -100,12 +100,8 @@ args: []
   # - --quiet
   # - --verbose
 
-# Tolerations to set for the `Pod`s managed by `DaemonSet`.
-tolerations:
-  # This toleration is to have the `DaemonSet` runnable on master nodes.
-  # Remove it if your masters can't run pods.
-  - key: node-role.kubernetes.io/master
-    effect: NoSchedule
+# Tolerations to set for the `Pod`s managed by `StatefulSet`.
+tolerations: []
 
 # Various tweakables for the `Pod`s managed by `StatefulSet`.
 resources: {}

--- a/charts/vector-aggregator/values.yaml
+++ b/charts/vector-aggregator/values.yaml
@@ -207,6 +207,7 @@ dnsConfig: {}
 
 # Configuration for both regular and headless `Service`.
 service:
+  annotations: {}
   # Service type - defaults to `ClusterIP` (only relevant for the regular service).
   type: "ClusterIP"
   # Additional ports to expose.


### PR DESCRIPTION
- Closes #22 Add missed templates from old helm charts
- Allow annotations to be set on Service resources, bump version
- Closes #11 Removes default toleration for Aggregator
- Closes #17 Add changelog for each chart