### PR TITLE
spencer/25 fix pvc labels

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,4 +99,4 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.1.0
       - name: Run chart-testing (install)
-        run: ct install --config .github/ct.yaml --excluded-charts vector-shared
+        run: ct install --config .github/ct.yaml --excluded-charts vector-shared --upgrade

--- a/charts/vector-aggregator/CHANGELOG.md
+++ b/charts/vector-aggregator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Vector Aggregator Changelog
 
+## 0.17.1
+
+* Remove labels on PersistentVolumeClaim that may change with upgrades
+  * NOTE: This bug blocks upgrades and requires the chart to be installed from scratch
+
 ## 0.17.0
 
 * Port `args`, `livenessProbe`, `readinessProbe`, `dnsPolicy`, `dnsConfig`, and `secrets` from original charts

--- a/charts/vector-aggregator/Chart.yaml
+++ b/charts/vector-aggregator/Chart.yaml
@@ -3,7 +3,7 @@ name: vector-aggregator
 type: application
 icon: https://vector.dev/press/vector-icon.svg
 description: A Helm chart to aggregate data with Vector
-version: "0.17.0"
+version: "0.17.1"
 appVersion: "0.16.1"
 home: https://vector.dev/
 sources:

--- a/charts/vector-aggregator/README.md
+++ b/charts/vector-aggregator/README.md
@@ -2,9 +2,6 @@
 
 This is an opinionated Helm Chart for running [Vector](https://vector.dev) as an [aggregator](https://vector.dev/docs/about/concepts/#aggregator) in Kubernetes.
 
-Our charts use Helm's dependency system, however we only use local dependencies.
-Head over to the repo for [more information on development and contribution](https://github.com/timberio/vector/tree/master/distribution/helm).
-
 To get started check out our [documentation](https://master.vector.dev/docs/setup/installation/platforms/kubernetes/)
 
 ## Load Balancing (Beta)

--- a/charts/vector-aggregator/ci/persistence-values.yaml
+++ b/charts/vector-aggregator/ci/persistence-values.yaml
@@ -1,0 +1,2 @@
+storage:
+  mode: managedPersistentVolumeClaim

--- a/charts/vector-aggregator/templates/statefulset.yaml
+++ b/charts/vector-aggregator/templates/statefulset.yaml
@@ -140,7 +140,8 @@ spec:
     - metadata:
         name: data-dir
         labels:
-          {{- include "libvector.labels" $ | nindent 10 }}
+          {{- include "libvector.selectorLabels" $ | nindent 10 }}
+          app.kubernetes.io/component: aggregator
           {{- with .labels }}
           {{- toYaml . | nindent 10 }}
           {{- end }}


### PR DESCRIPTION
- Remove labels from PVC that break the helm upgrade process
- Update ci to test upgrades, and add ci file for aggregator pvc

Fixes #25 
