### PR TITLE
spencer/vector alpha.2

### DIFF
--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vector
-version: "0.1.0-alpha.1"
-kubeVersion: ">=1.15.0"
+version: "0.1.0-alpha.2"
+kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application
 keywords:

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -15,7 +15,7 @@ helm repo update
 
 ## Requirements
 
-Kubernetes: `>=1.15.0`
+Kubernetes: `>=1.15.0-0`
 
 ## Quick start
 
@@ -80,6 +80,7 @@ helm install --name <RELEASE_NAME> \
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Allow Vector to schedule using affinity rules |
+| args | list | `["--config-dir","/etc/vector/"]` | Override Vector's default arguments |
 | autoscaling.customMetric | object | `{}` | Target a custom metric |
 | autoscaling.enabled | bool | `false` | Enabled autoscaling for the Stateless-Aggregator |
 | autoscaling.maxReplicas | int | `10` | Maximum replicas for Vector's HPA |
@@ -87,7 +88,7 @@ helm install --name <RELEASE_NAME> \
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization for Vector's HPA |
 | autoscaling.targetMemoryUtilizationPercentage | int | `nil` | Target memory utilization for Vector's HPA |
 | customConfig | object | `{}` | Override Vector's default configs, if used **all** options need to be specified |
-| env | list | `[]` | Set environment variables in the Vector container |
+| env | list | `[]` | Set environment variables in Vector containers |
 | image.pullPolicy | string | `"IfNotPresent"` | Vector image pullPolicy |
 | image.pullSecrets | list | `[]` | Agent repository pullSecret (ex: specify docker registry credentials) |
 | image.repository | string | `"timberio/vector"` | Override default registry + name for Vector |
@@ -101,15 +102,24 @@ helm install --name <RELEASE_NAME> \
 | persistence.hostPath.path | string | `"/var/lib/vector"` | Override path used for hostPath persistence |
 | persistence.selectors | object | `{}` | Specifies the selectors for PersistentVolumeClaims |
 | persistence.size | string | `"10Gi"` | Specifies the size of PersistentVolumeClaims |
+| podAnnotations | object | `{}` | Set annotations on Vector Pods |
+| podLabels | object | `{}` | Set labels on Vector Pods |
+| podPriorityClassName | string | `""` | Set the priorityClassName on Vector Pods |
 | podSecurityContext | object | `{}` | Allows you to overwrite the default PodSecurityContext for Vector |
 | rbac.create | bool | `true` | If true, create and use RBAC resources |
 | readinessProbe | object | `{}` | Override default readiness probe settings, if customConfig is used require customConfig.api.enabled true |
 | replicas | int | `1` | Set the number of Pods to create |
 | resources | object | `{}` | Set Vector resource requests and limits. |
-| role | string | `"Aggregator"` | Role for this deployment (possible values: Agent, Aggregator, Stateless-Aggregator) |
+| role | string | `"Aggregator"` | Role for this Vector (possible values: Agent, Aggregator, Stateless-Aggregator) |
+| rollWorkload | bool | `true` | Add a checksum of the generated ConfigMap to workload annotations |
 | secrets.generic | object | `{}` | Each Key/Value will be added to the Secret's data key |
-| securityContext | object | `{}` | Specify securityContext on the Vector container |
+| securityContext | object | `{}` | Specify securityContext on Vector containers |
+| service.annotations | object | `{}` | Set annotations on Vector's Service |
 | service.enabled | bool | `true` | If true, create and use a Service resource |
+| service.ports | list | `[]` | Override automated generation of Service ports |
+| service.type | string | `"ClusterIP"` | Set type of Vector's Service |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the Vector ServiceAccount |
+| serviceAccount.automountToken | bool | `true` | Automount API credentials for the Vector ServiceAccount |
 | serviceAccount.create | bool | `true` | If true, create ServiceAccount |
 | serviceAccount.name | string | `nil` | The name of the ServiceAccount to use. |
 | tolerations | list | `[]` | Allow Vector to schedule on tainted nodes |
@@ -134,11 +144,15 @@ helm install --name <RELEASE_NAME> \
 | haproxy.image.tag | string | `"2.4.4"` | HAProxy image tag to use |
 | haproxy.nodeSelector | object | `{}` | Allow HAProxy to be scheduled on selected nodes |
 | haproxy.podAnnotations | object | `{}` | Set annotations on HAProxy Pods |
+| haproxy.podLabels | object | `{}` | Set labels on HAProxy Pods |
+| haproxy.podPriorityClassName | string | `""` | Set the priorityClassName on HAProxy Pods |
 | haproxy.podSecurityContext | object | `{}` | Allows you to overwrite the default PodSecurityContext for HAProxy |
 | haproxy.replicas | int | `1` | Set the number of HAProxy Pods to create |
 | haproxy.resources | object | `{}` | Set HAProxy resource requests and limits. |
-| haproxy.securityContext | object | `{}` | Specify securityContext on the HAProxy container |
+| haproxy.securityContext | object | `{}` | Specify securityContext on HAProxy containers |
 | haproxy.service.type | string | `"ClusterIP"` | Set type of HAProxy's Service |
+| haproxy.serviceAccount.annotations | object | `{}` | Annotations to add to the HAProxy ServiceAccount |
+| haproxy.serviceAccount.automountToken | bool | `true` | Automount API credentials for the HAProxy ServiceAccount |
 | haproxy.serviceAccount.create | bool | `true` | If true, create a HAProxy ServiceAccount |
 | haproxy.serviceAccount.name | string | `nil` | The name of the HAProxy ServiceAccount to use. |
 | haproxy.terminationGracePeriodSeconds | int | `60` | Override HAProxy's terminationGracePeriodSeconds |

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.1.0-alpha.1](https://img.shields.io/badge/Version-0.1.0--alpha.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.1-distroless-libc](https://img.shields.io/badge/AppVersion-0.16.1--distroless--libc-informational?style=flat-square)
+![Version: 0.1.0-alpha.2](https://img.shields.io/badge/Version-0.1.0--alpha.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.1-distroless-libc](https://img.shields.io/badge/AppVersion-0.16.1--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -149,6 +149,7 @@ helm install --name <RELEASE_NAME> \
 | haproxy.podSecurityContext | object | `{}` | Allows you to overwrite the default PodSecurityContext for HAProxy |
 | haproxy.replicas | int | `1` | Set the number of HAProxy Pods to create |
 | haproxy.resources | object | `{}` | Set HAProxy resource requests and limits. |
+| haproxy.rollWorkload | bool | `true` | Add a checksum of the generated ConfigMap to the HAProxy Deployment |
 | haproxy.securityContext | object | `{}` | Specify securityContext on HAProxy containers |
 | haproxy.service.type | string | `"ClusterIP"` | Set type of HAProxy's Service |
 | haproxy.serviceAccount.annotations | object | `{}` | Annotations to add to the HAProxy ServiceAccount |

--- a/charts/vector/templates/NOTES.txt
+++ b/charts/vector/templates/NOTES.txt
@@ -4,23 +4,34 @@ __   __  __
   \_/  \/
 V E C T O R
 
-Vector is starting in your cluster. After a few minutes, you can use Vector's API to view internal metrics by running:
 {{ if (eq .Values.role "Aggregator") }}
   {{- if not .Values.customConfig }}
+Vector is starting in your cluster. After a few minutes, you can use Vector's API to view internal metrics by running:
+
 	kubectl -n {{ .Release.Namespace }} exec -it statefulset/{{ include "vector.fullname" . }} -- vector top 
-  {{- else }}
-	kubectl -n {{ .Release.Namespace }} exec -it statefulset/{{ include "vector.fullname" . }} -- vector top --url {{ .Values.customConfig.api.address }}
+  {{- else if .Values.customConfig.api.enabled }}
+Vector is starting in your cluster. After a few minutes, you can use Vector's API to view internal metrics by running:
+
+	kubectl -n {{ .Release.Namespace }} exec -it statefulset/{{ include "vector.fullname" . }} -- vector top --url {{ .Values.customConfig.api.address | default "http://127.0.0.1:8686/graphql" }}
   {{- end }}
 {{ else if (eq .Values.role "Stateless-Aggregator") }}
   {{- if not .Values.customConfig }}
+Vector is starting in your cluster. After a few minutes, you can use Vector's API to view internal metrics by running:
+
 	kubectl -n {{ .Release.Namespace }} exec -it deployment/{{ include "vector.fullname" . }} -- vector top 
-  {{- else }}
-	kubectl -n {{ .Release.Namespace }} exec -it deployment/{{ include "vector.fullname" . }} -- vector top --url {{ .Values.customConfig.api.address }}
+  {{- else if .Values.customConfig.api.enabled }}
+Vector is starting in your cluster. After a few minutes, you can use Vector's API to view internal metrics by running:
+
+	kubectl -n {{ .Release.Namespace }} exec -it deployment/{{ include "vector.fullname" . }} -- vector top --url {{ .Values.customConfig.api.address | default "http://127.0.0.1:8686/graphql" }}
   {{- end }}
 {{ else if (eq .Values.role "Agent") }}
   {{- if not .Values.customConfig }}
+Vector is starting in your cluster. After a few minutes, you can use Vector's API to view internal metrics by running:
+
 	kubectl -n {{ .Release.Namespace }} exec -it daemonset/{{ include "vector.fullname" . }} -- vector top 
-  {{- else }}
-	kubectl -n {{ .Release.Namespace }} exec -it daemonset/{{ include "vector.fullname" . }} -- vector top --url {{ .Values.customConfig.api.address }}
+  {{- else if .Values.customConfig.api.enabled }}
+Vector is starting in your cluster. After a few minutes, you can use Vector's API to view internal metrics by running:
+
+	kubectl -n {{ .Release.Namespace }} exec -it daemonset/{{ include "vector.fullname" . }} -- vector top --url {{ .Values.customConfig.api.address | default "http://127.0.0.1:8686/graphql" }}
   {{- end }}
 {{- end }}

--- a/charts/vector/templates/_pod.tpl
+++ b/charts/vector/templates/_pod.tpl
@@ -22,9 +22,10 @@ containers:
 {{- end }}
     image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
     imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{- with .Values.args }}
     args:
-      - --config-dir
-      - "/etc/vector/"
+    {{- toYaml . | nindent 6 }}
+{{- end }}
     env:
 {{- with .Values.env }}
     {{- toYaml . | nindent 6 }}

--- a/charts/vector/templates/_pod.tpl
+++ b/charts/vector/templates/_pod.tpl
@@ -19,6 +19,9 @@ containers:
       - --config-dir
       - "/etc/vector/"
     env:
+{{- with .Values.env }}
+    {{- toYaml . | nindent 6 }}
+{{- end }}
 {{- if (eq .Values.role "Agent") }}
       - name: VECTOR_SELF_NODE_NAME
         valueFrom:

--- a/charts/vector/templates/_pod.tpl
+++ b/charts/vector/templates/_pod.tpl
@@ -10,6 +10,10 @@ securityContext:
 {{- with .Values.priorityClassName }}
 priorityClassName: {{ . }}
 {{- end }}
+{{- with .Values.image.pullSecrets }}
+imagePullSecrets:
+{{ toYaml . | indent 2 }}
+{{- end }}
 containers:
   - name: vector
 {{- with .Values.securityContext }}

--- a/charts/vector/templates/_pod.tpl
+++ b/charts/vector/templates/_pod.tpl
@@ -7,6 +7,9 @@ serviceAccountName: {{ include "vector.serviceAccountName" . }}
 securityContext:
 {{ toYaml . | indent 2 }}
 {{- end }}
+{{- with .Values.priorityClassName }}
+priorityClassName: {{ . }}
+{{- end }}
 containers:
   - name: vector
 {{- with .Values.securityContext }}

--- a/charts/vector/templates/daemonset.yaml
+++ b/charts/vector/templates/daemonset.yaml
@@ -25,6 +25,9 @@ spec:
       labels:
         {{- include "vector.selectorLabels" . | nindent 8 }}
         vector.dev/exclude: "true"
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- include "vector.pod" . | nindent 6 }}
 {{- end }}

--- a/charts/vector/templates/daemonset.yaml
+++ b/charts/vector/templates/daemonset.yaml
@@ -15,8 +15,11 @@ spec:
   {{- end }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+      {{- if .Values.rollWorkload }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- end }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/charts/vector/templates/deployment.yaml
+++ b/charts/vector/templates/deployment.yaml
@@ -18,8 +18,11 @@ spec:
   {{- end }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+      {{- if .Values.rollWorkload }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- end }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/charts/vector/templates/deployment.yaml
+++ b/charts/vector/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
       {{- end }}
       labels:
         {{- include "vector.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- include "vector.pod" . | nindent 6 }}
 {{- end }}

--- a/charts/vector/templates/haproxy/deployment.yaml
+++ b/charts/vector/templates/haproxy/deployment.yaml
@@ -31,6 +31,9 @@ spec:
       serviceAccountName: {{ include "haproxy.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.haproxy.podSecurityContext | nindent 8 }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
         - name: haproxy
           securityContext:

--- a/charts/vector/templates/haproxy/deployment.yaml
+++ b/charts/vector/templates/haproxy/deployment.yaml
@@ -20,6 +20,9 @@ spec:
       {{- end }}
       labels:
         {{- include "haproxy.selectorLabels" . | nindent 8 }}
+      {{- with .Values.haproxy.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.haproxy.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/vector/templates/haproxy/deployment.yaml
+++ b/charts/vector/templates/haproxy/deployment.yaml
@@ -14,8 +14,11 @@ spec:
       {{- include "haproxy.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.haproxy.podAnnotations }}
       annotations:
+      {{- if .Values.haproxy.rollWorkload }}
+        checksum/config: {{ include (print $.Template.BasePath "haproxy/configmap.yaml") . | sha256sum }}
+      {{- end }}
+      {{- with .Values.haproxy.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/charts/vector/templates/haproxy/serviceaccount.yaml
+++ b/charts/vector/templates/haproxy/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.haproxy.serviceAccount.automountToken }}
 {{- end }}

--- a/charts/vector/templates/service-headless.yaml
+++ b/charts/vector/templates/service-headless.yaml
@@ -5,10 +5,16 @@ metadata:
   name: {{ include "vector.fullname" . }}-headless
   labels:
     {{- include "vector.labels" . | nindent 4 }}
+  annotations:
+  {{- with .Values.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   clusterIP: None
   ports:
-{{- if .Values.customConfig }}
+{{- if .Values.service.ports }}
+  {{- toYaml .Values.service.ports | nindent 4 }}
+{{- else if .Values.customConfig }}
   {{- include "vector.ports" . | indent 4 }}
 {{- else }}
     - name: datadog-agent

--- a/charts/vector/templates/service.yaml
+++ b/charts/vector/templates/service.yaml
@@ -5,9 +5,15 @@ metadata:
   name: {{ include "vector.fullname" . }}
   labels:
     {{- include "vector.labels" . | nindent 4 }}
+  annotations:
+  {{- with .Values.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
-{{- if .Values.customConfig }}
+{{- if .Values.service.ports }}
+  {{- toYaml .Values.service.ports | nindent 4 }}
+{{- else if .Values.customConfig }}
   {{- include "vector.ports" . | indent 4 }}
 {{- else if or (eq .Values.role "Aggregator") (eq .Values.role "Stateless-Aggregator") }}
     - name: datadog-agent
@@ -41,5 +47,5 @@ spec:
 {{- end }}
   selector:
     {{- include "vector.selectorLabels" . | nindent 4 }}
-  type: ClusterIP
+  type: {{ .Values.service.type }}
 {{- end }}

--- a/charts/vector/templates/serviceaccount.yaml
+++ b/charts/vector/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
 {{- end }}

--- a/charts/vector/templates/statefulset.yaml
+++ b/charts/vector/templates/statefulset.yaml
@@ -17,8 +17,11 @@ spec:
   serviceName: {{ template "vector.fullname" . }}-headless
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+      {{- if .Values.rollWorkload }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- end }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/charts/vector/templates/statefulset.yaml
+++ b/charts/vector/templates/statefulset.yaml
@@ -26,6 +26,9 @@ spec:
       {{- end }}
       labels:
         {{- include "vector.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- include "vector.pod" . | nindent 6 }}
   volumeClaimTemplates:

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -141,6 +141,12 @@ affinity: {}
 service:
   # service.enabled -- If true, create and use a Service resource
   enabled: true
+  # service.type -- Set type of Vector's Service
+  type: "ClusterIP"
+  # service.annotations -- Set annotations on Vector's Service
+  annotations: {}
+  # service.ports -- Override automated generation of Service ports
+  ports: []
 
 # customConfig -- Override Vector's default configs, if used **all** options need to be specified
 ## This section supports using helm templates to populate dynamic values

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -71,6 +71,9 @@ serviceAccount:
   ## If not set and create is true, a name is generated using the fullname template
   name:
 
+# podAnnotations -- Set annotations on Vector Pods
+podAnnotations: {}
+
 # podSecurityContext -- Allows you to overwrite the default PodSecurityContext for Vector
 podSecurityContext: {}
 

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -92,6 +92,11 @@ podSecurityContext: {}
 # securityContext -- Specify securityContext on Vector containers
 securityContext: {}
 
+# args -- Override Vector's default arguments
+args:
+  - --config-dir
+  - "/etc/vector/"
+
 # env -- Set environment variables in Vector containers
 env: []
   # - name: AWS_ACCESS_KEY_ID

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -10,6 +10,9 @@
 ## Stateless-Aggregator - Deployment
 role: "Aggregator"
 
+# rollWorkload -- Add a checksum of the generated ConfigMap to workload annotations
+rollWorkload: true
+
 ## Define the Vector image to use
 image:
   # image.repository -- Override default registry + name for Vector

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -2,7 +2,7 @@
 ## See Vector helm documentation to learn more:
 ## https://vector.dev/docs/setup/installation/package-managers/helm/
 
-# role -- Role for this deployment (possible values: Agent, Aggregator, Stateless-Aggregator)
+# role -- Role for this Vector (possible values: Agent, Aggregator, Stateless-Aggregator)
 ## Ref: https://vector.dev/docs/setup/deployment/roles/
 ## Each role is created with the following workloads:
 ## Agent - DaemonSet
@@ -83,16 +83,16 @@ podAnnotations: {}
 # podLabels -- Set labels on Vector Pods
 podLabels: {}
 
-# podPriorityClassName -- Set the priorityClassName on the Vector Pod
+# podPriorityClassName -- Set the priorityClassName on Vector Pods
 podPriorityClassName: ""
 
 # podSecurityContext -- Allows you to overwrite the default PodSecurityContext for Vector
 podSecurityContext: {}
 
-# securityContext -- Specify securityContext on the Vector container
+# securityContext -- Specify securityContext on Vector containers
 securityContext: {}
 
-# env -- Set environment variables in the Vector container
+# env -- Set environment variables in Vector containers
 env: []
   # - name: AWS_ACCESS_KEY_ID
   #   valueFrom:
@@ -227,14 +227,14 @@ haproxy:
   # haproxy.podLabels -- Set labels on HAProxy Pods
   podLabels: {}
 
-  # haproxy.podPriorityClassName -- Set the priorityClassName on the HAProxy Pod
+  # haproxy.podPriorityClassName -- Set the priorityClassName on HAProxy Pods
   podPriorityClassName: ""
 
   # haproxy.podSecurityContext -- Allows you to overwrite the default PodSecurityContext for HAProxy
   podSecurityContext: {}
     # fsGroup: 2000
 
-  # haproxy.securityContext -- Specify securityContext on the HAProxy container
+  # haproxy.securityContext -- Specify securityContext on HAProxy containers
   securityContext: {}
     # capabilities:
     #   drop:

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -66,10 +66,13 @@ rbac:
 serviceAccount:
   # serviceAccount.create -- If true, create ServiceAccount
   create: true
-
+  # serviceAccount.annotations -- Annotations to add to the Vector ServiceAccount
+  annotations: {}
   # serviceAccount.name -- The name of the ServiceAccount to use.
   ## If not set and create is true, a name is generated using the fullname template
   name:
+  # serviceAccount.automountToken -- Automount API credentials for the Vector ServiceAccount
+  automountToken: true
 
 # podAnnotations -- Set annotations on Vector Pods
 podAnnotations: {}
@@ -198,10 +201,13 @@ haproxy:
   serviceAccount:
     # haproxy.serviceAccount.create -- If true, create a HAProxy ServiceAccount
     create: true
-
+    # haproxy.serviceAccount.annotations -- Annotations to add to the HAProxy ServiceAccount
+    annotations: {}
     # haproxy.serviceAccount.name -- The name of the HAProxy ServiceAccount to use.
     ## If not set and create is true, a name is generated using the fullname template
     name:
+    # haproxy.serviceAccount.automountToken -- Automount API credentials for the HAProxy ServiceAccount
+    automountToken: true
 
   # haproxy.terminationGracePeriodSeconds -- Override HAProxy's terminationGracePeriodSeconds
   terminationGracePeriodSeconds: 60

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -83,6 +83,9 @@ podAnnotations: {}
 # podLabels -- Set labels on Vector Pods
 podLabels: {}
 
+# podPriorityClassName -- Set the priorityClassName on the Vector Pod
+podPriorityClassName: ""
+
 # podSecurityContext -- Allows you to overwrite the default PodSecurityContext for Vector
 podSecurityContext: {}
 
@@ -223,6 +226,9 @@ haproxy:
 
   # haproxy.podLabels -- Set labels on HAProxy Pods
   podLabels: {}
+
+  # haproxy.podPriorityClassName -- Set the priorityClassName on the HAProxy Pod
+  podPriorityClassName: ""
 
   # haproxy.podSecurityContext -- Allows you to overwrite the default PodSecurityContext for HAProxy
   podSecurityContext: {}

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -80,6 +80,9 @@ serviceAccount:
 # podAnnotations -- Set annotations on Vector Pods
 podAnnotations: {}
 
+# podLabels -- Set labels on Vector Pods
+podLabels: {}
+
 # podSecurityContext -- Allows you to overwrite the default PodSecurityContext for Vector
 podSecurityContext: {}
 
@@ -217,6 +220,9 @@ haproxy:
 
   # haproxy.podAnnotations -- Set annotations on HAProxy Pods
   podAnnotations: {}
+
+  # haproxy.podLabels -- Set labels on HAProxy Pods
+  podLabels: {}
 
   # haproxy.podSecurityContext -- Allows you to overwrite the default PodSecurityContext for HAProxy
   podSecurityContext: {}

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -215,6 +215,9 @@ haproxy:
     # haproxy.image.tag -- HAProxy image tag to use
     tag: "2.4.4"
 
+  # haproxy.rollWorkload -- Add a checksum of the generated ConfigMap to the HAProxy Deployment
+  rollWorkload: true
+
   # haproxy.replicas -- Set the number of HAProxy Pods to create
   replicas: 1
 


### PR DESCRIPTION
- fix: Add -0 to kubeVersion to fix comparison on EKS
- fix: Render env in pod template
- chore: Document podAnnotation option
- chore: Improve NOTES output accuracy
- feat: Document and implement serviceaccount options
- feat: Add checksum of generated configmap for all roles
- feat: Add podLabels for all workloads
- feat: Add priorityClassName for all workloads
- chore: Minor comments rewrites
- feat: Add pullSecrets to pod template
- feat: Set Vector args through values file
- feat: Allow for manual overriding of Service ports
- chore: Update docs
