### PR TITLE
feat: Add config for semantic PRs app

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,21 @@
+titleOnly: true
+
+scopes:
+  - vector
+  - vector-agent
+  - vector-aggregator
+  - vector-shared
+
+# Default
+types:
+  - feat
+  - fix
+  - docs
+  - style
+  - refactor
+  - perf
+  - test
+  - build
+  - ci
+  - chore
+  - revert

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ You need to add this repository to your Helm repositories:
 helm repo add vector https://helm.vector.dev
 helm repo update
 ```
+
+# Releasing
+
+Charts are packaged and released with [`cr`](https://github.com/helm/chart-releaser) when the `develop` branch is merged into `master`.


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Closes #39

As part of this, we also will be making the `develop` branch the **default** for the repo and only release charts when `develop` is merged into `master`
