### PR TITLE
fix: Add missing `/` to haproxy configmap path

### DIFF
--- a/charts/vector/Chart.yaml
+++ b/charts/vector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vector
-version: "0.1.0-alpha.2"
+version: "0.1.0-alpha.3"
 kubeVersion: ">=1.15.0-0"
 description: A lightweight, ultra-fast tool for building observability pipelines
 type: application

--- a/charts/vector/README.md
+++ b/charts/vector/README.md
@@ -1,6 +1,6 @@
 # Vector
 
-![Version: 0.1.0-alpha.2](https://img.shields.io/badge/Version-0.1.0--alpha.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.1-distroless-libc](https://img.shields.io/badge/AppVersion-0.16.1--distroless--libc-informational?style=flat-square)
+![Version: 0.1.0-alpha.3](https://img.shields.io/badge/Version-0.1.0--alpha.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.1-distroless-libc](https://img.shields.io/badge/AppVersion-0.16.1--distroless--libc-informational?style=flat-square)
 
 [Vector](https://vector.dev/) is a high-performance, end-to-end observability data pipeline that puts you in control of your observability data. Collect, transform, and route all your logs, metrics, and traces to any vendors you want today and any other vendors you may want tomorrow. Vector enables dramatic cost reduction, novel data enrichment, and data security where you need it, not where is most convenient for your vendors.
 

--- a/charts/vector/ci/haproxy-values.yaml
+++ b/charts/vector/ci/haproxy-values.yaml
@@ -1,0 +1,4 @@
+# HAProxy usage
+## Values file for testing HAProxy parameters.
+haproxy:
+  enabled: true

--- a/charts/vector/templates/haproxy/deployment.yaml
+++ b/charts/vector/templates/haproxy/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       annotations:
       {{- if .Values.haproxy.rollWorkload }}
-        checksum/config: {{ include (print $.Template.BasePath "haproxy/configmap.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/haproxy/configmap.yaml") . | sha256sum }}
       {{- end }}
       {{- with .Values.haproxy.podAnnotations }}
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@datadoghq.com>

Resolves the following issue:

```shell
Error: UPGRADE FAILED: template: vector/templates/haproxy/deployment.yaml:19:28: executing "vector/templates/haproxy/deployment.yaml" at <include (print $.Template.BasePath "haproxy/configmap.yaml") .>: error calling include: template: no template "vector/templateshaproxy/configmap.yaml" associated with template "gotpl"
```
